### PR TITLE
refactor: Fix comments

### DIFF
--- a/primitives/src/slider.rs
+++ b/primitives/src/slider.rs
@@ -294,10 +294,16 @@ pub fn SliderThumb(props: SliderThumbProps) -> Element {
     }
 }
 
-/// Function to perform linear scale transformation
-/// input: Input range [min, max]
-/// output: Output range [min, max]
-/// Returns: Transformation function
+/// Performs a linear scale transformation between two ranges.
+///
+/// # Arguments
+///
+/// * `input` - Input range [min, max]
+/// * `output` - Output range [min, max]
+///
+/// # Returns
+///
+/// A function that maps values from the input range to the output range
 fn linear_scale(input: [f64; 2], output: [f64; 2]) -> impl Fn(f64) -> f64 {
     let [in_min, in_max] = input;
     let [out_min, out_max] = output;
@@ -311,7 +317,19 @@ fn linear_scale(input: [f64; 2], output: [f64; 2]) -> impl Fn(f64) -> f64 {
     }
 }
 
-/// Function to get value from pointer position
+/// Calculates a value based on pointer position within a rectangle.
+///
+/// # Arguments
+///
+/// * `pointer_position` - The position of the pointer
+/// * `rect` - The rectangle reference area
+/// * `min` - The minimum value in the output range
+/// * `max` - The maximum value in the output range
+/// * `inverted` - Whether to invert the output range
+///
+/// # Returns
+///
+/// The calculated value within the range
 fn get_value_from_pointer(pointer_position: f64, rect: &Rect<f64, Pixels>, min: f64, max: f64, inverted: bool) -> f64 {
     let input = [0.0, rect.width()];
     let output = if !inverted { [min, max] } else { [max, min] };

--- a/primitives/src/slider.rs
+++ b/primitives/src/slider.rs
@@ -294,24 +294,24 @@ pub fn SliderThumb(props: SliderThumbProps) -> Element {
     }
 }
 
-/// 線形スケール変換を行う関数
-/// input: 入力範囲 [min, max]
-/// output: 出力範囲 [min, max]
-/// 戻り値: 変換関数
+/// Function to perform linear scale transformation
+/// input: Input range [min, max]
+/// output: Output range [min, max]
+/// Returns: Transformation function
 fn linear_scale(input: [f64; 2], output: [f64; 2]) -> impl Fn(f64) -> f64 {
     let [in_min, in_max] = input;
     let [out_min, out_max] = output;
     
     move |x: f64| {
-        // 入力範囲での位置を計算 (0.0 ~ 1.0)
+        // Calculate position in input range (0.0 ~ 1.0)
         let normalized = (x - in_min) / (in_max - in_min);
         
-        // 出力範囲に変換
+        // Convert to output range
         out_min + normalized * (out_max - out_min)
     }
 }
 
-/// ポインター位置から値を取得する関数
+/// Function to get value from pointer position
 fn get_value_from_pointer(pointer_position: f64, rect: &Rect<f64, Pixels>, min: f64, max: f64, inverted: bool) -> f64 {
     let input = [0.0, rect.width()];
     let output = if !inverted { [min, max] } else { [max, min] };


### PR DESCRIPTION
## Description
This PR translates Japanese comments in the slider.rs file to English for better international collaboration and code readability. It also updates the documentation style to follow Rust standard format.

## Changes
- Translated function documentation comments from Japanese to English
- Updated documentation style to follow Rust standard format with proper sections for Arguments and Returns
- Maintained the same meaning and context in the translations

## Related Issues
Part of the slider improvement work in the feature/slider-improve branch